### PR TITLE
fix to create output folder when missing

### DIFF
--- a/uTubeDwn.py
+++ b/uTubeDwn.py
@@ -16,7 +16,7 @@ ssl._create_default_https_context = ssl._create_stdlib_context
 def getTitle(url):
 	tmp = YouTube(url, use_oauth=True, allow_oauth_cache=True).title
 	#remove character not allowed on file system
-	tmp = re.sub(r'\w[.)]\s*', '', tmp)
+	tmp = re.sub(r'[^\w\s]', '', tmp)
 	return tmp
 
 # download only the video
@@ -56,6 +56,11 @@ def mergeVideoAudio(url):
 	audio = mp.AudioFileClip("./tmp/audio.mp4")
 	video1 = mp.VideoFileClip("./tmp/video.mp4")
 	final = video1.set_audio(audio)
+    
+    # Create output directory if it doesn't exist
+    if not os.path.exists("output"):
+        os.makedirs("output")  # Correct indentation (same as the if statement)
+        
 	final.write_videofile("output/"+getTitle(url)+".mp4",codec='libx264' ,audio_codec='libvorbis')
 
 def flushTmp():


### PR DESCRIPTION
When attempting to merge the video and audio, there was a missing validation to check if the output folder exists. This pull request addresses this issue by implementing the following improvements:

- **Output Folder Validation**: A check is added to verify if the output directory exists before attempting to write the merged video file. If the directory doesn't exist, it is created using` os.makedirs("output")`.

- **Enhanced Regular Expression**: The regular expression used to remove characters not allowed in the file system has been modified to better handle Spanish titles. This ensures that characters like accents and special characters are not inadvertently removed, preventing potential errors.